### PR TITLE
Remove 24 hour rate limiting time window

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries.mdx
@@ -92,16 +92,6 @@ For our [original data option](/docs/accounts/accounts-billing/new-relic-one-pri
         150 billion data points inspected (equivalent to a sustained rate of 10 billion data points inspected per minute)
       </td>
     </tr>
-
-    <tr>
-      <td>
-        24 hours
-      </td>
-
-      <td>
-        7.2 trillion data points inspected
-      </td>
-    </tr>
   </tbody>
 </table>
     


### PR DESCRIPTION
As of September 2022, New Relic no longer enforces a 24 hour inspected count limit.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.